### PR TITLE
Confirm dialog before connection delete

### DIFF
--- a/Sources/MHApplicationDelegate.m
+++ b/Sources/MHApplicationDelegate.m
@@ -312,8 +312,20 @@
 
 - (IBAction)deleteConnection:(id)sender
 {
-    [connectionsArrayController remove:sender];
-    [self saveConnections];
+    NSAlert *alert = [[[NSAlert alloc] init] autorelease];
+    [alert addButtonWithTitle:@"OK"];
+    [alert addButtonWithTitle:@"Cancel"];
+    [alert setMessageText:@"Delete the connection?"];
+    [alert setInformativeText:@"Deleted connections cannot be restored."];
+    [alert setAlertStyle:NSWarningAlertStyle];
+
+    NSInteger answer = [alert runModal];
+    alert = nil;
+    
+    if (answer == NSAlertFirstButtonReturn) {
+        [connectionsArrayController remove:sender];
+        [self saveConnections];
+    }
 }
 
 - (IBAction)showEditConnectionPanel:(id)sender


### PR DESCRIPTION
I've added confirm dialog before connection delete to avoid miss click to delete button.
