### PR TITLE
104 - Focus jumps to wrong tab on close

### DIFF
--- a/Sources/TabViews/MHTabViewController.m
+++ b/Sources/TabViews/MHTabViewController.m
@@ -137,7 +137,8 @@
         } else if (_selectedTabIndex == 0) {
             [self _tabItemViewControllerWithIndex:0];
         } else {
-            [self _tabItemViewControllerWithIndex:_selectedTabIndex - 1];
+            NSUInteger newIndex = index > _selectedTabIndex ? _selectedTabIndex : _selectedTabIndex - 1;
+            [self _tabItemViewControllerWithIndex: newIndex];
         }
         [self _updateTitleViewesWithAnimation:NO exceptView:nil];
         [self didChangeValueForKey:@"selectedTabIndex"];


### PR DESCRIPTION
#104 If the removed tab is to the right of the selected tab, keep the same index, otherwise, decrement to move leftward.
