### PR TITLE
Disable text replacements, automatic spell checking and switch to a fixed-width font for the Insert Data view

### DIFF
--- a/Sources/ConnectionWindow/MHQueryWindowController.m
+++ b/Sources/ConnectionWindow/MHQueryWindowController.m
@@ -225,6 +225,9 @@
     [self removeQueryComposer:nil];
     [self exportQueryComposer:nil];
     
+    // Using a fixed-width font is a little easier on the eyes when dealing with JavaScript objects.
+    [self.insertDataTextView setFont:[NSFont fontWithName:@"Menlo" size:12]];
+    
     // Disable spell checking and substitutions.
     // When dealing with JavaScript objects, switching regular double quotes into smart quotes isn't helpful.
     [self.insertDataTextView setAutomaticDashSubstitutionEnabled:NO];


### PR DESCRIPTION
I found myself swearing at MongoHub when trying to insert a large number of objects in one go, and then discovered that it was because of OS X's "helpful" text substitutions and, in some cases, the automatic spelling corrections. I've now disabled these.

I've also taken the liberty of switching the insert data view to using a fixed-width font, which – in this developer's humble opinion – makes a lot more sense than using a variable-width font.

Incidentally, it looks like I'm not alone – and this closes #121.

Thanks for maintaining MongoHub!
