### PR TITLE
Moved Contribute to before History and created Contributors section in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,9 +39,7 @@ Please [send me a pull request](https://github.com/jeromelebel/MongoHub-Mac/pull
 ## Contributors (in reverse order of contribution)
 
 ### 2014-12-28 [ssteinerX](https://github.com/ssteinerx) 
-    ```
     #184 Removed duplicate collection name when generating displayed query string
-    ```
 
 ## History
 


### PR DESCRIPTION
I think it's important to get requests for contributions, and attributions to contributors into the README where they might actually be seen.

Only credited myself as getting link information for previous pull requests was quite convoluted; maybe you have a better way...
