### PR TITLE
Respect default database in connection settings when user doesn't have full admin privs

### DIFF
--- a/Sources/ConnectionWindow/MHConnectionWindowController.m
+++ b/Sources/ConnectionWindow/MHConnectionWindowController.m
@@ -251,7 +251,7 @@
     result = [self.client databaseNamesWithCallback:^(NSArray *list, MODQuery *mongoQuery) {
         [self.loaderIndicator stopAnimation:nil];
         self.window.title = self.connectionStore.alias;
-        if (list != nil) {
+        if (list != nil && list.count) {
             if ([self.clientItem updateChildrenWithList:list]) {
                 [self.databaseCollectionOutlineView reloadData];
             }


### PR DESCRIPTION
When using services like Compose.io/MongoHQ the databaseNamesWithCallback returns an empty but non null NSArray because user is not an admin user. In this case MongoHub should fall back to the default database as specified in the connection settings. This pull request makes MongoHub usable again for services like Compose.io/MongoHQ where the user you authenticate with a user that doesn't have full admin privs to read list of databases on server, but you specify a default database.